### PR TITLE
Do not generate field label if it was passed as undef explicitly

### DIFF
--- a/Form-Diva/lib/Form/Diva.pm
+++ b/Form-Diva/lib/Form/Diva.pm
@@ -180,12 +180,15 @@ sub _label {
     # http://www.w3.org/TR/html5/forms.html#the-label-element
     my $self  = shift;
     my $field = shift;
+
+    return '' if exists $field->{label} && !defined $field->{label};
+
     my $label_class
         = $field->{label_class}
         ? $field->{label_class}
         : $self->{label_class};
     my $label_tag
-        = $field->{label} ? $field->{label} : ucfirst( $field->{name} );
+        = exists $field->{label} ? $field->{label} || '' : ucfirst( $field->{name} );
     return qq|<LABEL for="$field->{id}" id="$field->{id}_label" class="$label_class">|
         . qq|$label_tag</LABEL>|;
 }
@@ -392,7 +395,7 @@ PLAINLOOP:
             comment => $field->{comment},
         );
         $row{label}
-            = $field->{label} ? $field->{label} : ucfirst( $field->{name} );
+            = exists $field->{label} ? $field->{label} || '' : ucfirst( $field->{name} );
         $row{id} = $field->{id}
             ; # coverage testing deletion ? $field->{id} : 'formdiva_' . $field->{name};
         if ($moredata) {

--- a/Form-Diva/t/130_label.t
+++ b/Form-Diva/t/130_label.t
@@ -27,6 +27,14 @@ my $diva1 = Form::Diva->new(
             label_class => 'not_that_class we_can_override_label_class',
             label   => 'Label Over-Ride',
         },
+        {   name => 'no_label',
+            type => 'text',
+            label => undef,
+        },
+        {   name => 'empty_label',
+            type => 'text',
+            label => '',
+        },
 
     ],
 );
@@ -60,7 +68,13 @@ foreach my $test (
     ],
     [   $diva1->_label( $fields[4] ),
         '<LABEL for="formdiva_label_over" id="formdiva_label_over_label" class="not_that_class we_can_override_label_class">Label Over-Ride</LABEL>'
-    ],    
+    ],
+    [   $diva1->_label( $fields[5] ),
+        ''
+    ],
+    [   $diva1->_label( $fields[6] ),
+        '<LABEL for="formdiva_empty_label" id="formdiva_empty_label_label" class="testclass"></LABEL>'
+    ],
     [   $diva2->_label( $radiofields[0] ),
         '<LABEL for="formdiva_radiotest" id="formdiva_radiotest_label" class="testclass">Radiotest</LABEL>'
     ],


### PR DESCRIPTION
It seems like a good idea to me. More info in the linked issue.

Closes #6