### PR TITLE
Generate placeholders regardless of form data availability

### DIFF
--- a/Form-Diva/lib/Form/Diva.pm
+++ b/Form-Diva/lib/Form/Diva.pm
@@ -162,13 +162,16 @@ sub _field_bits {
         $out{rawvalue} = $data->{$fname} || '';
     }
     else {
-        if ( $in{placeholder} ) {
-            $out{placeholder} = qq!placeholder="$in{placeholder}"!;
-        }
-        else { $out{placeholder} = '' }
         if   ( $in{default} ) { $out{rawvalue} = $in{default}; }
         else                  { $out{rawvalue} = '' }
     }
+    if ( $in{placeholder} ) {
+        $out{placeholder} = qq!placeholder="$in{placeholder}"!;
+    }
+    else {
+        $out{placeholder} = '';
+    }
+
     $out{value} = qq!value="$out{rawvalue}"!;
     return %out;
 }
@@ -348,7 +351,6 @@ sub prefill {
         my $iname = $item->{name};
         if ( $data->{$iname} ) {
             $item->{default} = $data->{$iname};
-            delete $item->{placeholder};
         }
     }
     my $generated = $self->generate( undef, $overide );
@@ -411,3 +413,4 @@ PLAINLOOP:
 }
 
 1;
+

--- a/Form-Diva/t/102_fieldbits.t
+++ b/Form-Diva/t/102_fieldbits.t
@@ -32,7 +32,7 @@ my $diva1 = Form::Diva->new(
         },
     ],
     hidden =>
-        [ { n => 'secret' }, 
+        [ { n => 'secret' },
         { n => 'hush', default => 'very secret' }, ],
 );
 
@@ -93,7 +93,7 @@ foreach my $nametest (
 
 foreach my $test (
     [ 'input_class', 'class="form-control"' ],
-    [ 'placeholder', '' ],
+    [ 'placeholder', 'placeholder="Your Name"' ],
     [ 'rawvalue',    'Baloney' ],
     [ 'value',       'value="Baloney"' ],
     )
@@ -101,7 +101,7 @@ foreach my $test (
     tester( \%name_data1, 'name_data1', $test->[0], $test->[1] );
 }
 foreach my $test (
-    [ 'placeholder', '' ],
+    [ 'placeholder', 'placeholder="Your Name"' ],
     [ 'rawvalue',    'Salami' ],
     [ 'value',       'value="Salami"' ],
     )
@@ -138,7 +138,7 @@ foreach my $emailtest (
 
 foreach my $emailtest2 (
     [ 'type',        'type="email"' ],
-    [ 'placeholder', '' ],
+    [ 'placeholder', 'placeholder="doormat"' ],
     [ 'id',          'id="formdiva_email"' ],
     [ 'name',        'name="email"' ],
     [ 'rawvalue',    'salami@yapc.org' ],
@@ -191,3 +191,4 @@ tester(
 );
 
 done_testing;
+

--- a/Form-Diva/t/150_input.t
+++ b/Form-Diva/t/150_input.t
@@ -69,8 +69,6 @@ unlike( $name_no_data_tr, qr/"\w""/,
 
 my $name_data1_tr = $diva1->_input( $fields[0], $data1 );
 #note("Input Element for name_data1_tr: $name_data1_tr");
-unlike( $name_data1_tr, qr/placeholder/,
-    'Input with data has no placeholder' );
 like( $name_data1_tr, qr/ value="Baloney"/, 'Value set: value="Baloney" ' );
 
 my $ourid_no_data_tr = $diva1->_input( $fields[3] );
@@ -107,3 +105,4 @@ unlike( $trivial_tr, qr/form-control/,
     'the default class isnt in the input' );
 
 done_testing;
+

--- a/Form-Diva/t/203_prefill.t
+++ b/Form-Diva/t/203_prefill.t
@@ -19,7 +19,7 @@ sub Tester {
     elsif ( $testType eq 'unlike'){
         unlike( $generated->[ $row ]{ input },
             qr/$input/, "$comment  -- $input");}
-    else { fail( "Ivalid testType $testType provided for test: $comment") }    
+    else { fail( "Ivalid testType $testType provided for test: $comment") }
 }
 
 my $diva1 = Form::Diva->new(
@@ -28,10 +28,10 @@ my $diva1 = Form::Diva->new(
     form_name => 'diva1',
     form        => [
         { n => 'name', t => 'text', p => 'Your Name', l => 'Full Name' },
-        { name => 'phone', type => 'tel', extra => 'required', 
+        { name => 'phone', type => 'tel', extra => 'required',
             comment => 'phoney phooey', default => 'say Hello' },
         {qw / n email t email l Email c form-email placeholder doormat/},
-        { name => 'our_id', type => 'number', 
+        { name => 'our_id', type => 'number',
                 extra => 'disabled', placeholder => 11 },
         {  name => 'onemore', default => 'old college try' },
         {   name    => 'checktest',
@@ -59,47 +59,49 @@ my $data2 = {
 # need to create series of tests, several iterations of prefill and then do a plain generate to
 # confirm original default/placholder still exist.
 my @results1 = (
-    {   row => 0 ,  input => q|value="spaghetti"|, 
+    {   row => 0 ,  input => q|value="spaghetti"|,
         comment => 'prefilled name with value spaghetti is set'},
-    {   row => 1 ,  input => q|value="say Hello"|, 
-        comment => 'prefilled with no value for phone gets default'},    
-    {   row => 2 ,    input => q|value="dinner\@food.food"|, 
-        comment => 'prefilled email with value dinner@food.food is set'},   
-    {   row => 3 ,  input => q|value=""|,  
+    {   row => 0 ,  input => q|placeholder="Your Name"|,
+        comment => 'prefilled name with value gets placeholder of "Your Name"'},
+    {   row => 1 ,  input => q|value="say Hello"|,
+        comment => 'prefilled with no value for phone gets default'},
+    {   row => 2 ,    input => q|value="dinner\@food.food"|,
+        comment => 'prefilled email with value dinner@food.food is set'},
+    {   row => 3 ,  input => q|value=""|,
         comment => 'prefilled our_id with no value gets no value'},
-    {   row => 3 ,  input => q|placeholder="11"|, 
-        comment => 'prefilled our_id with no value gets placeholder of 11'},    
-    {   row => 4 ,    input => q|value="old college try"|, 
-        comment => 'prefilled with no value for onemore gets default'},            
+    {   row => 3 ,  input => q|placeholder="11"|,
+        comment => 'prefilled our_id with no value gets placeholder of 11'},
+    {   row => 4 ,    input => q|value="old college try"|,
+        comment => 'prefilled with no value for onemore gets default'},
     {   row => 5 ,    input => q|checked="checked">French|, testType => 'like',
-        comment => 'checkbox has selected French'},         
+        comment => 'checkbox has selected French'},
     {   row => 5 ,    input => q|"checked">Argentinian|, testType => 'unlike',
-        comment => 'confirm that another item is not checked'},              
+        comment => 'confirm that another item is not checked'},
 );
 
 my @results2 = (
-    {   row => 0 ,  input => q|value="Coffee"|, 
+    {   row => 0 ,  input => q|value="Coffee"|,
         comment => 'prefilled name with value Coffee is set'},
-    {   row => 1 ,  input => q|value="say Hello"|, 
-        comment => 'prefilled with no value for phone gets default'},    
-    {   row => 2 ,    input => q|placeholder="doormat"|, 
-        comment => 'doormat is the placeholder (default) for email'},   
-    {   row => 3 ,  input => q|value=""|,  
+    {   row => 1 ,  input => q|value="say Hello"|,
+        comment => 'prefilled with no value for phone gets default'},
+    {   row => 2 ,    input => q|placeholder="doormat"|,
+        comment => 'doormat is the placeholder (default) for email'},
+    {   row => 3 ,  input => q|value=""|,
         comment => 'prefilled our_id with no value gets no value'},
-    {   row => 3 ,  input => q|placeholder="11"|, 
-        comment => 'prefilled our_id with no value gets placeholder of 11'},    
-    {   row => 4 ,    input => q|value="old college try"|, 
-        comment => 'prefilled with no value for onemore gets default'},            
+    {   row => 3 ,  input => q|placeholder="11"|,
+        comment => 'prefilled our_id with no value gets placeholder of 11'},
+    {   row => 4 ,    input => q|value="old college try"|,
+        comment => 'prefilled with no value for onemore gets default'},
     {   row => 5 ,    input => q|checked="checked">Irish|, testType => 'like',
-        comment => 'checkbox has selected Irish'},         
+        comment => 'checkbox has selected Irish'},
     {   row => 5 ,    input => q|"checked">Argentinian|, testType => 'unlike',
-        comment => 'confirm that another item is not checked'},              
+        comment => 'confirm that another item is not checked'},
 );
 
 my $nodatagenerate = $diva1->generate ;
 my $nodataprefill = $diva1->prefill ;
 
-is_deeply( $nodataprefill, $nodatagenerate, 
+is_deeply( $nodataprefill, $nodatagenerate,
     "With no data prefill and generate return the same" );
 
 my $data_prefill_1 = $diva1->prefill( $data1 );
@@ -109,7 +111,8 @@ my $data_prefill_2 = $diva1->prefill( $data2 );
 foreach my $test ( @results2) { Tester( $data_prefill_2, $test ) }
 
 my $post_generate = $diva1->generate ;
-is_deeply( $post_generate, $nodatagenerate, 
+is_deeply( $post_generate, $nodatagenerate,
     "Generate without Data returns the same after prefill was used as it did before." );
 
 done_testing();
+


### PR DESCRIPTION
Placeholders are used in text input / textarea fields, where they do not
clash with actual values and only become visible when the text is
deleted. Always generating them should be more consistent than doing so
conditionally.

Resolves #9 