### PR TITLE
Better HTML tags generation mechanism

### DIFF
--- a/Form-Diva/README.md
+++ b/Form-Diva/README.md
@@ -268,7 +268,13 @@ Form::Diva is meant to be used with a Templating System. [Template::Toolkit](htt
 
 # AUTHOR
 
-John Karr, `brainbuz at brainbuz.org`
+John Karr [BRAINBUZ](https://metacpan.org/author/BRAINBUZ)
+
+## CONTRIBUTORS
+
+Bartosz Jarzyna [BRTASTIC](https://metacpan.org/author/BRTASTIC)
+
+Mohammad S Anwar [MANWAR](https://metacpan.org/author/MANWAR)
 
 # BUGS
 

--- a/Form-Diva/lib/Form/Diva.pm
+++ b/Form-Diva/lib/Form/Diva.pm
@@ -40,6 +40,30 @@ sub _field_once {
     return 1;
 }
 
+sub _build_html_tag {
+    my $self = shift;
+    my $tag_name = shift;
+    my %options = @_;
+    my @attrs = grep { defined && length } @{ $options{attributes} // [] };
+
+    my $output = join ' ', $tag_name, @attrs;
+    $output = "<$output>";
+
+    if (exists $options{content}) {
+        $output .= join '', $options{content} // '', "</$tag_name>";
+    }
+
+    if (defined $options{prefix}) {
+        $output = $options{prefix} . $output;
+    }
+
+    if (defined $options{suffix}) {
+        $output .= $options{suffix};
+    }
+
+    return $output;
+}
+
 sub new {
     my $class = shift;
     my $self  = {@_};
@@ -192,8 +216,15 @@ sub _label {
         : $self->{label_class};
     my $label_tag
         = exists $field->{label} ? $field->{label} || '' : ucfirst( $field->{name} );
-    return qq|<LABEL for="$field->{id}" id="$field->{id}_label" class="$label_class">|
-        . qq|$label_tag</LABEL>|;
+
+    return $self->_build_html_tag('LABEL',
+        attributes => [
+            qq|for="$field->{id}"|,
+            qq|id="$field->{id}_label"|,
+            qq|class="$label_class"|,
+        ],
+        content => $label_tag
+    );
 }
 
 sub _input {
@@ -203,12 +234,29 @@ sub _input {
     my %B     = $self->_field_bits( $field, $data );
     my $input = '';
     if ( $B{textarea} ) {
-        $input = qq|<TEXTAREA $B{name} $B{id}
-        $B{input_class} $B{placeholder} $B{extra} >$B{rawvalue}</TEXTAREA>|;
+        $input = $self->_build_html_tag('TEXTAREA',
+            attributes => [
+                $B{name},
+                $B{id},
+                $B{input_class},
+                $B{placeholder},
+                $B{extra},
+            ],
+            content => $B{rawvalue}
+        );
     }
     else {
-        $input .= qq|<INPUT $B{type} $B{name} $B{id}
-        $B{input_class} $B{placeholder} $B{extra} $B{value} >|;
+        $input = $self->_build_html_tag('INPUT',
+            attributes => [
+                $B{type},
+                $B{name},
+                $B{id},
+                $B{input_class},
+                $B{placeholder},
+                $B{extra},
+                $B{value},
+            ],
+        );
     }
     return $input;
 }
@@ -220,10 +268,16 @@ sub _input_hidden {
     my %B     = $self->_field_bits( $field, $data );
 
     #hidden fields don't get a class or a placeholder
-    my $input .= qq|<INPUT type="hidden" $B{name} $B{id}
-        $B{extra} $B{value} >|;
-    $input =~ s/\s+/ /g;     # remove extra whitespace.
-    $input =~ s/\s+>/>/g;    # cleanup space before closing >
+    my $input = $self->_build_html_tag('INPUT',
+        attributes => [
+            qq|type="hidden"|,
+            $B{name},
+            $B{id},
+            $B{extra},
+            $B{value},
+        ],
+    );
+
     return $input;
 }
 
@@ -269,33 +323,64 @@ sub _option_input {    # field, input_class, data;
         ? @{$replace_fields}
         : @{ $field->{values} };
     if ( $field->{type} eq 'select' ) {
-        $output
-            = qq|<SELECT name="$field->{name}" id="$field->{id}" $extra $input_class>\n|;
+        my @options;
         foreach my $val (@values) {
             my ( $value, $v_lab ) = ( split( /\:/, $val ), $val );
             my $idf = $self->_option_id( $field->{id}, $value );
             my $selected = '';
-            if    ( $datavalue eq $value ) { $selected = 'selected ' }
-            elsif ( $default eq $value )   { $selected = 'selected ' }
-            $output
-                .= qq| <option value="$value" $idf $selected>$v_lab</option>\n|;
+            if    ( $datavalue eq $value ) { $selected = 'selected' }
+            elsif ( $default eq $value )   { $selected = 'selected' }
+
+            push @options, $self->_build_html_tag('option',
+                attributes => [
+                    qq|value="$value"|,
+                    $idf,
+                    $selected,
+                ],
+                content => $v_lab,
+                prefix => ' ',
+                suffix => "\n",
+            );
         }
-        $output .= '</SELECT>';
+
+        $output = $self->_build_html_tag('SELECT',
+            attributes => [
+                qq|name="$field->{name}"|,
+                qq|id="$field->{id}"|,
+                $extra,
+                $input_class
+            ],
+            # NOTE: add an empty line before first option
+            content => (join '', "\n", @options),
+        );
     }
     else {
+        my @options;
         foreach my $val (@values) {
             my ( $value, $v_lab ) = ( split( /\:/, $val ), $val );
             my $idf = $self->_option_id( $field->{id}, $value );
             my $checked = '';
             if ( $datavalue eq $value ) {
-                $checked = q !checked="checked" !;
+                $checked = q !checked="checked"!;
             }
             elsif ( $default eq $value ) {
-                $checked = q !checked="checked" !;
+                $checked = q !checked="checked"!;
             }
-            $output
-                .= qq!<input type="$field->{type}" $input_class $extra name="$field->{name}" $idf value="$value" $checked>$v_lab<br>\n!;
+            push @options, $self->_build_html_tag('input',
+                attributes => [
+                    qq|type="$field->{type}"|,
+                    $input_class,
+                    $extra,
+                    qq|name="$field->{name}"|,
+                    $idf,
+                    qq|value="$value"|,
+                    $checked
+                ],
+                suffix => "$v_lab<br>\n"
+            );
         }
+
+        $output = join '', @options;
     }
     return $output;
 }
@@ -330,8 +415,6 @@ sub generate {
         else {
             $input = $self->_input( $field, $data );
         }
-        $input =~ s/  +/ /g;     # remove extra whitespace.
-        $input =~ s/\s+>/>/g;    # cleanup space before closing >
         push @generated,
             {
             label   => $self->_label($field),

--- a/Form-Diva/t/170_checkboxes.t
+++ b/Form-Diva/t/170_checkboxes.t
@@ -11,7 +11,7 @@ use_ok('Form::Diva');
 Reminder when writing/modifying tests involving _option_input:
 
 %id_uq needs to be cleared before each test invoking _option_input.
-normally generate would do this but when we're testing 
+normally generate would do this but when we're testing
 private methods this isn't happening.
 
 =cut
@@ -20,7 +20,7 @@ my $radio1 = Form::Diva->new(
     label_class => 'testclass',
     input_class => 'form-control',
     form        => [
-        { n => 'radiotest', t => 'radio', 
+        { n => 'radiotest', t => 'radio',
         v => [ qw /American English Canadian/ ] },
     ],
 );
@@ -29,7 +29,7 @@ my $check1 = Form::Diva->new(
     label_class => 'testclass',
     input_class => 'form-control',
     form        => [
-        { name => 'checktest', type => 'checkbox', 
+        { name => 'checktest', type => 'checkbox',
         values => [ qw /French Irish Russian/ ] },
     ],
 );
@@ -39,8 +39,8 @@ my $labels1 = Form::Diva->new(
     input_class => 'form-control',
     form        => [
         { name => 'withlabels', type => 'radio', default => 1,
-        values => [ 
-        	"1:Peruvian Music", 
+        values => [
+        	"1:Peruvian Music",
         	"2:Argentinian Dance",
         	"3:Cuban" ] },
     ],
@@ -49,14 +49,14 @@ my $labels1 = Form::Diva->new(
 my ($newform) = $radio1->_expandshortcuts( $radio1->{form} );
 
 my $testradio1values = $newform->[0]{values};
-is( $newform->[0]{type}, 'radio', 
+is( $newform->[0]{type}, 'radio',
 		'input is radio');
 is( $testradio1values->[2], 'Canadian', 'Test _expandshortcuts for values' );
 
 my $radio_nodata_expected =<< 'RNDX' ;
-<input type="radio" class="form-control"  name="radiotest" id="formdiva_radiotest_american" value="American" >American<br>
-<input type="radio" class="form-control"  name="radiotest" id="formdiva_radiotest_english" value="English" >English<br>
-<input type="radio" class="form-control"  name="radiotest" id="formdiva_radiotest_canadian" value="Canadian" >Canadian<br>
+<input type="radio" class="form-control" name="radiotest" id="formdiva_radiotest_american" value="American">American<br>
+<input type="radio" class="form-control" name="radiotest" id="formdiva_radiotest_english" value="English">English<br>
+<input type="radio" class="form-control" name="radiotest" id="formdiva_radiotest_canadian" value="Canadian">Canadian<br>
 RNDX
 
 my $radio1_data_expected =<< 'RDX' ;
@@ -93,10 +93,10 @@ my @check1_nodata = @{ $check1->generate };
 is( $check1_nodata[0]->{input}, $check_nodata_expected, 'generated as 3 checkboxes.');
 
 my @labels1_nodata = @{ $labels1->generate} ;
-is( $labels1_nodata[0]->{input}, $labels1_nodata_expected , 
+is( $labels1_nodata[0]->{input}, $labels1_nodata_expected ,
 	'Default checked is Peruvian Music');
 my @labels1_data = @{ $labels1->generate( { withlabels => 2 })} ;
-is( $labels1_data[0]->{input}, $labels1_data_expected , 
+is( $labels1_data[0]->{input}, $labels1_data_expected ,
     'With Data check Argentinian Dance instead.');
 
 my $classoverride1 = Form::Diva->new(
@@ -117,9 +117,10 @@ like( $classoverridden[0]->{input}, qr/class="not-default"/ ,
 like( $classoverridden[0]->{input}, qr/disabled/ ,
 		"Check the extra field, we set value to disabled." );
 
-my $over_ride_checkbox = $classoverride1->generate( 
+my $over_ride_checkbox = $classoverride1->generate(
     { radiotest => 'Venus' }, { radiotest => [ qw / Mars Venus Earth Jupiter /] } );
 like( $over_ride_checkbox->[0]{input} , qr/value="Venus" checked="checked">Venus/,
     'overridden checkbox Venus is selected');
 unlike( $over_ride_checkbox->[0]{input} , qr/Canadian/, 'overridden value is not present' );
 done_testing();
+

--- a/Form-Diva/t/180_select.t
+++ b/Form-Diva/t/180_select.t
@@ -11,7 +11,7 @@ use_ok('Form::Diva');
 Reminder when writing/modifying tests involving _option_input:
 
 %id_uq needs to be cleared before each test invoking _option_input.
-normally generate would do this but when we're testing 
+normally generate would do this but when we're testing
 private methods this isn't happening.
 
 =cut
@@ -60,26 +60,26 @@ my ($newform) = $select1->_expandshortcuts( $select1->{form} );
 
 is( $newform->[0]{type}, 'select', 'check _expandshortcuts type is select' );
 
-my $input_select3_default = 
- q |<SELECT name="checktest" id="checktest"  class="form-control">
- <option value="Argentinian" id="checktest_argentinian" >Argentinian</option>
- <option value="American" id="checktest_american" >American</option>
- <option value="English" id="checktest_english" >English</option>
- <option value="Canadian" id="checktest_canadian" >Canadian</option>
- <option value="French" id="checktest_french" selected >French</option>
- <option value="Irish" id="checktest_irish" >Irish</option>
- <option value="Russian" id="checktest_russian" >Russian</option>
+my $input_select3_default =
+ q |<SELECT name="checktest" id="checktest" class="form-control">
+ <option value="Argentinian" id="checktest_argentinian">Argentinian</option>
+ <option value="American" id="checktest_american">American</option>
+ <option value="English" id="checktest_english">English</option>
+ <option value="Canadian" id="checktest_canadian">Canadian</option>
+ <option value="French" id="checktest_french" selected>French</option>
+ <option value="Irish" id="checktest_irish">Irish</option>
+ <option value="Russian" id="checktest_russian">Russian</option>
 </SELECT>|;
 
-$select1->_clear_id_uq ; 
+$select1->_clear_id_uq ;
 unlike( $select1->_option_input( $select1->{form}[0], undef ),
     qr/selected/,
     'select1 does not have a default, with no data nothing is selected' );
 
-$select1->_clear_id_uq ; 
+$select1->_clear_id_uq ;
 
-my $uk_selected = $select1->_option_input( 
-    $select1->{FormHash}{selecttest}, 
+my $uk_selected = $select1->_option_input(
+    $select1->{FormHash}{selecttest},
         { selecttest => 'uk' });
 
 like(
@@ -89,55 +89,55 @@ like(
 );
 like(
     $uk_selected,
-    qr/usa" >American/,
+    qr/usa">American/,
     'select1 with uk as data "usa">American has tag and not selected'
 );
 
-my $empty_input_nodata = 
-    qq|<SELECT name="empty" id="formdiva_empty"  class="form-control">\n</SELECT>|;
+my $empty_input_nodata =
+    qq|<SELECT name="empty" id="formdiva_empty" class="form-control">\n</SELECT>|;
 
-$select2->_clear_id_uq();    
+$select2->_clear_id_uq();
 is( $select2->_option_input( $select2->{form}[0] ) ,
     $empty_input_nodata ,
     'select2 has no values provided and returns with no option elements');
 my $select2_no_data = $select2->generate ;
-is( $select2_no_data->[0]{label}, 
+is( $select2_no_data->[0]{label},
     '<LABEL for="formdiva_empty" id="formdiva_empty_label" class="testclass">Empty</LABEL>',
     'Check the label on the empty one');
 # remove extra space because generate does.
 $empty_input_nodata =~ s/\s//g;
 my $generated_empty_input = $select2_no_data->[0]{input};
 $generated_empty_input =~ s/\s//g;
-is( $generated_empty_input, 
+is( $generated_empty_input,
     $empty_input_nodata,
     'Generate returned input of a few tests ago, with some space removed' );
 
 $select3->_clear_id_uq;
 my $input3a = $select3->_option_input( $select3->{form}[0], undef, );
-is( $input3a, $input_select3_default, 
+is( $input3a, $input_select3_default,
     'A select with different labels than values.' );
 
 $select2->_clear_id_uq;
-my $over_ride2 = $select2->_option_input( 
+my $over_ride2 = $select2->_option_input(
     $select2->{form}[0], undef, [ qw / yellow orange red / ] );
-like( $over_ride2, qr/red/, 
+like( $over_ride2, qr/red/,
     'Empty Select with Override now has one of the new vaues' )   ;
-unlike( $over_ride2, qr/selected/, 
+unlike( $over_ride2, qr/selected/,
     'Empty Select with Override has no selected because it was given undef' )   ;
 
 $select3->_clear_id_uq;
-my $over_ride3 = $select3->_option_input( 
-    $select3->{form}[0], 
-    { checktest => 'pear' }, 
+my $over_ride3 = $select3->_option_input(
+    $select3->{form}[0],
+    { checktest => 'pear' },
     [ qw / apple orange pear / ] );
-unlike ( $over_ride3, qr/French/, 
+unlike ( $over_ride3, qr/French/,
     'Select with Override does not contain an original option value');
-like( $over_ride3, qr/apple/, 
+like( $over_ride3, qr/apple/,
     'Select with Override does contain one of the new values' )   ;
-like( $over_ride3, qr/<option value="pear" id="checktest_pear" selected >/,
+like( $over_ride3, qr/<option value="pear" id="checktest_pear" selected>/,
     'pear is selected in the Override select');
 
-my $over_ride4 = $select3->generate( 
+my $over_ride4 = $select3->generate(
     { checktest  => 'banana' , pet => 'poodle' },
     { checktest => [ qw / banana grape peach plum / ] } );
 
@@ -147,3 +147,4 @@ unlike( $over_ride4->[0]{input} , qr/Canadian/, 'Canadian has been removed' );
 
 
 done_testing();
+

--- a/Form-Diva/t/201_generate.t
+++ b/Form-Diva/t/201_generate.t
@@ -12,7 +12,7 @@ my $diva1 = Form::Diva->new(
     form_name => 'diva1',
     form        => [
         { n => 'name', t => 'text', p => 'Your Name', l => 'Full Name' },
-        { name => 'phone', type => 'tel', extra => 'required', 
+        { name => 'phone', type => 'tel', extra => 'required',
             comment => 'phoney phooey', default => 'say Hello' },
         {qw / n email t email l Email c form-email placeholder doormat/},
         { name => 'our_id', type => 'number', extra => 'disabled' },
@@ -22,45 +22,45 @@ my $diva1 = Form::Diva->new(
 
 note( 'a few example tests with some small data.');
 my $data1 = {
-    name   => 'spaghetti',
+    name   => 'spaghetti   bolognese',
     our_id => 41,
     email  => 'dinner@food.food',
 };
 my $processed1 = $diva1->generate( $data1 );
 like( $processed1->[3]{input}, qr/name="our_id"/, 'Check row3 name in input tag.');
 like( $processed1->[3]{input}, qr/value="41"/, 'Check row3 value in input tag.');
-like( $processed1->[0]{input}, qr/class="form-control"/, 
+like( $processed1->[0]{input}, qr/class="form-control"/,
     'Row 0 has default class tag.');
-like( $processed1->[2]{input}, qr/class="form-email"/, 
-    'Row 2 has over-ridden class tag.');    
-like( $processed1->[0]{input}, qr/value="spaghetti"/, 
-    'Row 0 has value of spaghetti.');
-like( $processed1->[4]{input}, qr/value=""/, 
+like( $processed1->[2]{input}, qr/class="form-email"/,
+    'Row 2 has over-ridden class tag.');
+like( $processed1->[0]{input}, qr/value="spaghetti   bolognese"/,
+    'Row 0 has value of spaghetti   bolognese.');
+like( $processed1->[4]{input}, qr/value=""/,
     'Row 4 has empty value set.');
-like( $processed1->[2]{input}, qr/value="dinner\@food\.food"/, 
+like( $processed1->[2]{input}, qr/value="dinner\@food\.food"/,
     'Row 2 has a value like the email address.');
 
 is( $processed1->[0]{comment}, undef, 'first field has no comment' );
-is( $processed1->[1]{comment}, 
+is( $processed1->[1]{comment},
     'phoney phooey', 'second field has comment of \'phoney phooey\'' );
 
 
 note( 'a few example tests with no data.');
 my $processed2 = $diva1->generate();
 like( $processed2->[3]{input}, qr/name="our_id"/, 'Check row3 name in input tag.');
-like( $processed2->[0]{input}, qr/class="form-control"/, 
+like( $processed2->[0]{input}, qr/class="form-control"/,
     'Row 0 has default class tag.');
-like( $processed2->[2]{input}, qr/class="form-email"/, 
-    'Row 2 has over-ridden class tag.');    
-like( $processed2->[1]{input}, qr/value="say Hello"/, 
+like( $processed2->[2]{input}, qr/class="form-email"/,
+    'Row 2 has over-ridden class tag.');
+like( $processed2->[1]{input}, qr/value="say Hello"/,
     'Row 1 has default value set.');
-like( $processed2->[2]{input}, qr/value=""/, 
+like( $processed2->[2]{input}, qr/value=""/,
     'Row 2 has empty value set.');
-like( $processed2->[3]{input}, qr/value=""/, 
+like( $processed2->[3]{input}, qr/value=""/,
     'Check row3 has empty value set.');
-like( $processed2->[2]{input}, qr/placeholder="doormat"/, 
+like( $processed2->[2]{input}, qr/placeholder="doormat"/,
     'Row 2 has placeholder set.');
- 
+
 my @html_types = (
     {qw / n color t color l Colour /},
     {qw / n date   t date   l Date /},
@@ -105,3 +105,4 @@ for ( my $i = 0; $i < scalar(@html_types); $i++ ) {
 }
 
 done_testing();
+

--- a/Form-Diva/t/202_generate_options.t
+++ b/Form-Diva/t/202_generate_options.t
@@ -31,7 +31,7 @@ my $diva = Form::Diva->new(
             default => 2,
             values => [ '1:This', '2:That', '3:Something Else'],
         },
-        { 
+        {
             name => 'defaultzero',
             type => 'radio',
             default => 0,
@@ -52,17 +52,17 @@ is( $basic->[0]{input},
 </SELECT>|,
     'Check our select input, it has no elements' );
 
-like( $basic->[1]{input}, qr/name="checktest"/, 
+like( $basic->[1]{input}, qr/name="checktest"/,
     'input name is checktest');
-like( $basic->[1]{input}, qr/type="checkbox"/, 
+like( $basic->[1]{input}, qr/type="checkbox"/,
     'checktest is a checkbox');
-like( $basic->[1]{input}, qr/value="French" checked/, 
+like( $basic->[1]{input}, qr/value="French" checked/,
     'French is checked');
-like( $basic->[2]{input}, qr/name="radiotest"/, 
+like( $basic->[2]{input}, qr/name="radiotest"/,
     'input name is radiotest');
-like( $basic->[2]{input}, qr/type="radio"/, 
+like( $basic->[2]{input}, qr/type="radio"/,
     'radiotest is a radio');
-like( $basic->[2]{input}, qr/value="2" checked/, 
+like( $basic->[2]{input}, qr/value="2" checked/,
     'Value 2 is checked');
 like( $basic->[3]{input},
     qr/value="0" checked="checked"/,
@@ -74,23 +74,24 @@ my $data1 = {
 
 note( 'repeat the last generation with some data');
 my $basic_data = $diva->generate( $data1 );
-unlike( $basic_data->[1]{input}, qr/value="French" checked/, 
+unlike( $basic_data->[1]{input}, qr/value="French" checked/,
     'French is no lnger checked');
-like( $basic_data->[1]{input}, qr/value="Canadian" checked/, 
+like( $basic_data->[1]{input}, qr/value="Canadian" checked/,
     'Canadian is now checked');
-like( $basic_data->[2]{input}, qr/value="1" checked/, 
+like( $basic_data->[2]{input}, qr/value="1" checked/,
     'Value 1 is now checked in the radio');
 unlike( $basic_data->[3]{input},
     qr/value="0" checked="checked"/,
     "defaultzero value is not checked because there was data for other fields");
 
 note( 'override the empty list in the select');
-my $over = $diva->generate( {empty => 'dog'}, { 
+my $over = $diva->generate( {empty => 'dog'}, {
     empty => [ qw/ cat mouse dog rabbit deer /] }
     );
-like( $over->[0]{input}, qr/rabbit/, 
+like( $over->[0]{input}, qr/rabbit/,
     'rabbit now has an entry in select');
-like( $over->[0]{input}, qr/selected>dog/, 
+like( $over->[0]{input}, qr/selected>dog/,
     'selected dog in the data and dog is now selected');
 
 done_testing();
+

--- a/Form-Diva/t/300_clone.t
+++ b/Form-Diva/t/300_clone.t
@@ -62,7 +62,7 @@ is( $diva4->{FormMap}[3]{id}, 'mystery_site_url',
 
 my $generated4 = $diva4->generate ;
 is( $generated4->[2]{input},
-    qq(<INPUT type="text" name="secret" id="formdiva_secret"\n class="different" value="">),
+    qq(<INPUT type="text" name="secret" id="formdiva_secret" class="different" value="">),
     'previously hidden field is now a textfield'     );
 is( $generated4->[2]{label},
    '<LABEL for="formdiva_secret" id="formdiva_secret_label" class="testclass">Secret</LABEL>',
@@ -77,3 +77,4 @@ like( $generated4->[3]{input},
    qr/custom="bizarre"/,
    'extra for previously hidden field in generated input' );
 done_testing();
+


### PR DESCRIPTION
Resolves #10 

With the new `_build_html_tag` method, there's no need to clear any whitespace anymore. This method will not generate extra spaces between attributes when some of the attributes are empty.

This way the module still tests correctly (after minor whitespace changes in strings), but it should no longer break on doubled spaces as explained in the issue. I implemented (reused) a test which makes sure extra spaces are preserved.